### PR TITLE
pl-748 swtich-getShipmentReceiptsAll-to-use-get-all

### DIFF
--- a/dist/SoftLedgerAPI.js
+++ b/dist/SoftLedgerAPI.js
@@ -220,11 +220,11 @@ class SoftLedgerAPI {
         return this.instance.post('/salesOrders', payload);
     }
     completeSalesOrder(id) {
-		return this.instance.put(`/salesOrders/${id}/complete`);
-	}
-	uncompleteSalesOrder(id) {
-		return this.instance.put(`/salesOrders/${id}/uncomplete`);
-	}
+        return this.instance.put(`/salesOrders/${id}/complete`);
+    }
+    uncompleteSalesOrder(id) {
+        return this.instance.put(`/salesOrders/${id}/uncomplete`);
+    }
     getSOAllLineItems() {
         return this._getAll(this.instance, '/salesOrders/lineItems');
     }
@@ -310,7 +310,7 @@ class SoftLedgerAPI {
         return this.instance.get(`/shipmentReceipts/${id}/lineItems`);
     }
     getShipmentReceiptAllLineItems(params) {
-        return this.instance.get(`/shipmentReceipts/lineItems`, params);
+        return this._getAll(this.instance, `/shipmentReceipts/lineItems`, params);
     }
     createShipmentReceipt(payload) {
         return this.instance.post('/shipmentReceipts', payload);

--- a/src/SoftLedgerAPI.ts
+++ b/src/SoftLedgerAPI.ts
@@ -86,7 +86,7 @@ export class SoftLedgerAPI {
 		instance: AxiosInstance,
 		url: string,
 		params: object = {}
-	): Promise<AxiosResponse<ListResponse<any>>> {
+	): Promise<AxiosResponse<any>> {
 		// Wrapper Promise -- loads an initial chunk and returns that promise immediately if it contains all of the data. If not
 		// this promise will call additional chunks in sequences and append them to the initial promise's data. Returns the modified
 		// initial promise when all chunks are loaded to make it appear that all data was returned in a single call to upstream applications.
@@ -487,7 +487,7 @@ export class SoftLedgerAPI {
 	}
 
 	getShipmentReceiptAllLineItems(params: object): Promise<AxiosResponse<ShipmentReceiptLine[]>> {
-		return this.instance.get(`/shipmentReceipts/lineItems`, params);
+		return this._getAll(this.instance, `/shipmentReceipts/lineItems`, params);
 	}
 
 	createShipmentReceipt(


### PR DESCRIPTION
Updating the SoftLedgerSDK to use getAll for the get shipment reciept line items, which removes the need for double params in the middleware code (Plus fixes a potential bug if there are ever more than 25 SR line items for a single PO line item.)