### PR TITLE
redownloaded npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "soft-ledger-sdk",
-	"version": "1.0.11",
+	"version": "1.0.14",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -717,7 +717,7 @@
 			"version": "27.0.1",
 			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
 			"integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
-			"devOptional": true,
+			"dev": true,
 			"requires": {
 				"jest-diff": "^27.0.0",
 				"pretty-format": "^27.0.0"
@@ -1843,8 +1843,7 @@
 		"jest-pnp-resolver": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"requires": {}
+			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
 		},
 		"jest-regex-util": {
 			"version": "27.0.6",
@@ -2852,8 +2851,7 @@
 		"ws": {
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-			"integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-			"requires": {}
+			"integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",


### PR DESCRIPTION
something is going wrong when I try to reference the new tag (1.0.14) in the MW package.json - this may fix it