### PR TITLE
change type and bumping version

### DIFF
--- a/dist/types/purchaseOrders/CreatePurchaseOrderRequest.d.ts
+++ b/dist/types/purchaseOrders/CreatePurchaseOrderRequest.d.ts
@@ -32,4 +32,5 @@ export declare type CreatePurchaseOrderRequestPOLineItem = {
 	KitId?: number;
 	TaxCodeId?: number;
 	SalesOrderId?: number;
+	SOLineItemId?: string;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "soft-ledger-sdk",
-	"version": "1.0.21",
+	"version": "1.0.22",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/src/types/purchaseOrders/CreatePurchaseOrderRequest.ts
+++ b/src/types/purchaseOrders/CreatePurchaseOrderRequest.ts
@@ -33,4 +33,5 @@ export type CreatePurchaseOrderRequestPOLineItem = {
 	KitId?: number;
 	TaxCodeId?: number;
 	SalesOrderId?: number;
+	SOLineItemId?: string;
 };


### PR DESCRIPTION
Small change to make eslint not be red for the new field the fix in the mw is using for pl-1797

@GregTimmons  sidenote it would be nice if all the sl-related type definitions didin't live in here... not sure how easy it would be to transport these into the mw, but it could be worth it so we don't have to go through: **_make sdk change => bump package.json version => pr process and merge => update sdk tag => update sdk version in mw (and ideally parts app too) package.json_** every time just to change a type definition