### PR TITLE
pl-2655 Fix not using cache on first auth

### DIFF
--- a/dist/v2/SoftLedgerApiBase.js
+++ b/dist/v2/SoftLedgerApiBase.js
@@ -50,7 +50,7 @@ class SoftLedgerAPIBase {
 		}
 	}
 	getInstance() {
-		return this.authedInstancePromise || this.authenticate();
+		return this.authedInstancePromise || this.authenticate(true);
 	}
 	authenticate(useCache = false) {
 		this.authedInstancePromise = (() =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "soft-ledger-sdk",
-	"version": "2.0.9",
+	"version": "2.0.10",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/src/v2/SoftLedgerApiBase.ts
+++ b/src/v2/SoftLedgerApiBase.ts
@@ -36,7 +36,7 @@ export abstract class SoftLedgerAPIBase {
 	//    Promise.all(sl.Vendor_find(), sl.Warehouse_find());
 	//
 	protected getInstance(): Promise<AxiosInstance> {
-		return this.authedInstancePromise || this.authenticate();
+		return this.authedInstancePromise || this.authenticate(true);
 	}
 
 	private authenticate(useCache: boolean = false): Promise<AxiosInstance> {


### PR DESCRIPTION
The authentication needs to use the cache on inital auth, and only do `useCache = false` in the case of fail auth with the old cached token to work correctly. 

Updating the flag on initialize to ensure this is the case. 