### PR TITLE
Pl 2950 correct stock summary api

### DIFF
--- a/dist/types/purchaseOrders/PurchaseOrderRequest.d.ts
+++ b/dist/types/purchaseOrders/PurchaseOrderRequest.d.ts
@@ -4,7 +4,7 @@ export interface UpdatePurchaseOrderRequest {
 	VendorId?: number;
 	LocationId?: number;
 	currency?: string;
-	WarehouseId?: string;
+	WarehouseId?: number;
 	POLineItems?: UpdatePurchaseOrderLineItemRequest[];
 	externalId?: string;
 	description?: string;
@@ -23,6 +23,6 @@ export interface CreatePurchaseOrderRequest extends UpdatePurchaseOrderRequest {
 	VendorId: number;
 	LocationId: number;
 	currency: string;
-	WarehouseId: string;
+	WarehouseId: number;
 	POLineItems?: CreatePurchaseOrderLineItemRequest[];
 }

--- a/dist/types/salesOrders/SalesOrder.d.ts
+++ b/dist/types/salesOrders/SalesOrder.d.ts
@@ -30,6 +30,7 @@ export declare type SalesOrderLineItem = {
 			name: string;
 		};
 	};
+	PurchaseOrderId?: number;
 	POLineItemId?: number;
 	POLineItem?: PurchaseOrderLineItem;
 	ItemId?: number;

--- a/dist/v2/SoftLedgerAPI.js
+++ b/dist/v2/SoftLedgerAPI.js
@@ -117,7 +117,7 @@ class SoftLedgerAPI extends SoftLedgerApiBase_1.SoftLedgerAPIBase {
 	}
 	Item_stockSummary(id) {
 		return __awaiter(this, void 0, void 0, function* () {
-			return this.getAllSubEntity(types_1.Entity.Item, types_1.Entity.StockSummary, id);
+			return this.getOneSubEntity(types_1.Entity.Item, types_1.Entity.StockSummary, id);
 		});
 	}
 	Item_update(id, data) {

--- a/dist/v2/SoftLedgerApiBase.d.ts
+++ b/dist/v2/SoftLedgerApiBase.d.ts
@@ -23,6 +23,7 @@ export declare abstract class SoftLedgerAPIBase {
 	private query;
 	protected getNoArgs<T>(entity: Entity, options: t.SoftLedgerSDKOptions): Promise<T>;
 	protected getOne<T>(entity: Entity, id: t.NumericId, options: t.SoftLedgerSDKOptions): Promise<T>;
+	protected getOneSubEntity<T>(entity: Entity, subEntity: Entity, id: t.NumericId, options?: t.SoftLedgerSDKOptions): Promise<T>;
 	protected getOneWithCustomType<T, U>(entity: Entity, id: U, options: t.SoftLedgerSDKOptions): Promise<T>;
 	private _getAll;
 	protected getAll<T>(entity: Entity, options?: t.SoftledgerGetRequest<any>): Promise<Array<T>>;

--- a/dist/v2/SoftLedgerApiBase.js
+++ b/dist/v2/SoftLedgerApiBase.js
@@ -158,6 +158,11 @@ class SoftLedgerAPIBase {
 			return this.query((i) => i.get(`/${entity}/${id}`), options);
 		});
 	}
+	getOneSubEntity(entity, subEntity, id, options) {
+		return __awaiter(this, void 0, void 0, function* () {
+			return this.query((i) => i.get(`/${entity}/${id}/${subEntity}`), options);
+		});
+	}
 	getOneWithCustomType(entity, id, options) {
 		return __awaiter(this, void 0, void 0, function* () {
 			return this.query((i) => i.get(`/${entity}/${id}`), options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "soft-ledger-sdk",
-	"version": "2.0.16",
+	"version": "2.0.17",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/src/types/purchaseOrders/PurchaseOrderRequest.ts
+++ b/src/types/purchaseOrders/PurchaseOrderRequest.ts
@@ -5,7 +5,7 @@ export interface UpdatePurchaseOrderRequest {
 	VendorId?: number;
 	LocationId?: number;
 	currency?: string;
-	WarehouseId?: string;
+	WarehouseId?: number;
 	POLineItems?: UpdatePurchaseOrderLineItemRequest[];
 
 	externalId?: string;
@@ -26,6 +26,6 @@ export interface CreatePurchaseOrderRequest extends UpdatePurchaseOrderRequest {
 	VendorId: number;
 	LocationId: number;
 	currency: string;
-	WarehouseId: string;
+	WarehouseId: number;
 	POLineItems?: CreatePurchaseOrderLineItemRequest[];
 }

--- a/src/types/salesOrders/SalesOrder.ts
+++ b/src/types/salesOrders/SalesOrder.ts
@@ -31,6 +31,7 @@ export type SalesOrderLineItem = {
 			name: string;
 		};
 	};
+	PurchaseOrderId?: number;
 	POLineItemId?: number;
 	POLineItem?: PurchaseOrderLineItem;
 	ItemId?: number;

--- a/src/v2/SoftLedgerAPI.ts
+++ b/src/v2/SoftLedgerAPI.ts
@@ -59,7 +59,9 @@ export class SoftLedgerAPI extends SoftLedgerAPIBase {
 		return this.getOne<t.Item>(Entity.Item, id, options);
 	}
 	public async Item_stockSummary(id: t.NumericId) {
-		return this.getAllSubEntity<t.ItemStockSummary>(Entity.Item, Entity.StockSummary, id);
+		// Note: 'getAll' in this API implies iterating through data pages. ItemSummary returns an unpaged list, so we use getOne,
+		//       though the one thing it gets is a list of summary items.
+		return this.getOneSubEntity<t.ItemStockSummary[]>(Entity.Item, Entity.StockSummary, id);
 	}
 	public async Item_update(id: t.NumericId, data: t.CreateItemRequest) {
 		return this.update<t.Item, t.CreateItemRequest>(Entity.Item, id, data);

--- a/src/v2/SoftLedgerApiBase.ts
+++ b/src/v2/SoftLedgerApiBase.ts
@@ -128,6 +128,10 @@ export abstract class SoftLedgerAPIBase {
 		return this.query<T>((i) => i.get(`/${entity}/${id}`), options);
 	}
 
+	protected async getOneSubEntity<T>(entity: Entity, subEntity: Entity, id: t.NumericId, options?: t.SoftLedgerSDKOptions): Promise<T> {
+		return this.query<T>((i) => i.get(`/${entity}/${id}/${subEntity}`), options);
+	}
+
 	protected async getOneWithCustomType<T, U>(entity: Entity, id: U, options: t.SoftLedgerSDKOptions): Promise<T> {
 		return this.query<T>((i) => i.get(`/${entity}/${id}`), options);
 	}


### PR DESCRIPTION
3 minor correction to the SDK for things in the MW api. 

ItemStockSummary attempted to page from a return that wasn't paged. 
PurchaseOrderRequest warehouse type changed from string to number in v2, but not updated in the SDK
SOLineItems now include 'PurchaseOrderId' in get one SO body, updating type to reflect. 